### PR TITLE
Pass dots through `vec_ptype()` and `vec_ptype_finalise()`

### DIFF
--- a/R/iv.R
+++ b/R/iv.R
@@ -256,14 +256,14 @@ is_iv <- function(x) {
 #' @export
 vec_ptype.ivs_iv <- function(x, ...) {
   start <- unclass(x)[[1L]]
-  ptype <- vec_ptype(start)
+  ptype <- vec_ptype(start, ...)
   new_bare_iv(ptype, ptype)
 }
 
 #' @export
 vec_ptype_finalise.ivs_iv <- function(x, ...) {
   start <- unclass(x)[[1L]]
-  ptype <- vec_ptype_finalise(start)
+  ptype <- vec_ptype_finalise(start, ...)
   new_bare_iv(ptype, ptype)
 }
 


### PR DESCRIPTION
See https://github.com/DavisVaughan/ivs/pull/34#discussion_r990963230

These are incredibly unlikely to error on `start`, because `start` will have already been validated to be a vector type in `iv()`, so we shouldn't need to worry about tweaking the `x_arg` to mention that the error would really be coming from `iv_start({x_arg})`.

CC @lionel-