### PR TITLE
Add `relationship` argument to locate functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,11 @@
   class. This should result in slightly better performance when combining many
   ivs together (#27).
 
+* `iv_locate_overlaps()`, `iv_locate_precedes()`, `iv_locate_follows()`,
+  `iv_locate_between()`, and `iv_locate_includes()` have all gained the
+  `relationship` argument from the underlying engine,
+  `vctrs::vec_locate_matches()` (#45).
+
 * `iv_proxy()` now returns the input unchanged if it doesn't implement an S3
   method, rather than erroring. In combination with `is_iv()`, this provides a
   way to check if an input implements a proxy method and to implement different

--- a/R/containers.R
+++ b/R/containers.R
@@ -155,7 +155,7 @@ iv_identify_container <- function(x) {
     needles = x,
     haystack = containers,
     type = "within",
-    multiple = "error"
+    relationship = "many-to-one"
   ))
 
   out <- vec_slice(containers, loc$haystack)
@@ -187,9 +187,9 @@ iv_locate_containers <- function(x) {
 
 
 with_multiple_containers_errors <- function(expr, error_call = caller_env()) {
-  try_fetch(
+  withCallingHandlers(
     expr = expr,
-    vctrs_error_matches_multiple = function(cnd) {
+    vctrs_error_matches_relationship_many_to_one = function(cnd) {
       stop_multiple_containers(cnd$i, error_call = error_call)
     }
   )

--- a/R/relation.R
+++ b/R/relation.R
@@ -436,7 +436,8 @@ iv_locate_overlaps <- function(needles,
                                missing = "equals",
                                no_match = NA_integer_,
                                remaining = "drop",
-                               multiple = "all") {
+                               multiple = "all",
+                               relationship = "none") {
   check_dots_empty0(...)
 
   args <- vec_cast_common(needles = needles, haystack = haystack)
@@ -458,6 +459,7 @@ iv_locate_overlaps <- function(needles,
     no_match = no_match,
     remaining = remaining,
     multiple = multiple,
+    relationship = relationship,
     error_call = current_env()
   )
 }
@@ -583,7 +585,8 @@ iv_locate_precedes <- function(needles,
                                missing = "equals",
                                no_match = NA_integer_,
                                remaining = "drop",
-                               multiple = "all") {
+                               multiple = "all",
+                               relationship = "none") {
   check_dots_empty0(...)
 
   iv_locate_positional(
@@ -594,7 +597,8 @@ iv_locate_precedes <- function(needles,
     missing = missing,
     no_match = no_match,
     remaining = remaining,
-    multiple = multiple
+    multiple = multiple,
+    relationship = relationship
   )
 }
 
@@ -607,7 +611,8 @@ iv_locate_follows <- function(needles,
                               missing = "equals",
                               no_match = NA_integer_,
                               remaining = "drop",
-                              multiple = "all") {
+                              multiple = "all",
+                              relationship = "none") {
   check_dots_empty0(...)
 
   iv_locate_positional(
@@ -618,7 +623,8 @@ iv_locate_follows <- function(needles,
     missing = missing,
     no_match = no_match,
     remaining = remaining,
-    multiple = multiple
+    multiple = multiple,
+    relationship = relationship
   )
 }
 
@@ -630,6 +636,7 @@ iv_locate_positional <- function(needles,
                                  no_match,
                                  remaining,
                                  multiple,
+                                 relationship,
                                  ...,
                                  error_call = caller_env()) {
   check_dots_empty0(...)
@@ -672,6 +679,7 @@ iv_locate_positional <- function(needles,
     no_match = no_match,
     remaining = remaining,
     multiple = multiple,
+    relationship = relationship,
     error_call = error_call
   )
 }
@@ -1106,7 +1114,8 @@ iv_locate_relates <- function(needles,
                               missing = "equals",
                               no_match = NA_integer_,
                               remaining = "drop",
-                              multiple = "all") {
+                              multiple = "all",
+                              relationship = "none") {
   check_dots_empty0(...)
 
   args <- vec_cast_common(needles = needles, haystack = haystack)
@@ -1129,6 +1138,7 @@ iv_locate_relates <- function(needles,
     no_match = no_match,
     remaining = remaining,
     multiple = multiple,
+    relationship = relationship,
     error_call = current_env()
   )
 }

--- a/R/vector.R
+++ b/R/vector.R
@@ -113,7 +113,8 @@ iv_locate_between <- function(needles,
                               missing = "equals",
                               no_match = NA_integer_,
                               remaining = "drop",
-                              multiple = "all") {
+                              multiple = "all",
+                              relationship = "none") {
   check_dots_empty0(...)
 
   iv_locate_vector(
@@ -125,7 +126,8 @@ iv_locate_between <- function(needles,
     missing = missing,
     no_match = no_match,
     remaining = remaining,
-    multiple = multiple
+    multiple = multiple,
+    relationship = relationship
   )
 }
 
@@ -137,7 +139,8 @@ iv_locate_includes <- function(needles,
                                missing = "equals",
                                no_match = NA_integer_,
                                remaining = "drop",
-                               multiple = "all") {
+                               multiple = "all",
+                               relationship = "none") {
   check_dots_empty0(...)
 
   iv_locate_vector(
@@ -149,7 +152,8 @@ iv_locate_includes <- function(needles,
     missing = missing,
     no_match = no_match,
     remaining = remaining,
-    multiple = multiple
+    multiple = multiple,
+    relationship = relationship
   )
 }
 
@@ -162,6 +166,7 @@ iv_locate_vector <- function(x,
                              no_match,
                              remaining,
                              multiple,
+                             relationship,
                              ...,
                              error_call = caller_env()) {
   check_dots_empty0(...)
@@ -209,6 +214,7 @@ iv_locate_vector <- function(x,
     no_match = no_match,
     remaining = remaining,
     multiple = multiple,
+    relationship = relationship,
     needles_arg = needles_arg,
     haystack_arg = haystack_arg,
     error_call = error_call
@@ -365,6 +371,10 @@ iv_count_vector <- function(x,
   # Obviously we are trying to count all of the matches
   multiple <- "all"
 
+  # None of the "count" functions currently expose `relationship`.
+  # We could do this eventually if it seems useful.
+  relationship <- "none"
+
   locations <- iv_locate_vector(
     x = x,
     y = y,
@@ -375,6 +385,7 @@ iv_count_vector <- function(x,
     no_match = translate_count_no_match(no_match),
     remaining = remaining,
     multiple = multiple,
+    relationship = relationship,
     error_call = error_call
   )
 

--- a/man/allen-relation-locate.Rd
+++ b/man/allen-relation-locate.Rd
@@ -13,7 +13,8 @@ iv_locate_relates(
   missing = "equals",
   no_match = NA_integer_,
   remaining = "drop",
-  multiple = "all"
+  multiple = "all",
+  relationship = "none"
 )
 }
 \arguments{
@@ -93,6 +94,47 @@ which match will be returned. It is often faster than \code{"first"} and
 \item \code{"first"} returns the first match detected in \code{haystack}.
 \item \code{"last"} returns the last match detected in \code{haystack}.
 }}
+
+\item{relationship}{Handling of the expected relationship between
+\code{needles} and \code{haystack}. If the expectations chosen from the list below
+are invalidated, an error is thrown.
+\itemize{
+\item \code{"none"} doesn't perform any relationship checks.
+\item \code{"one-to-one"} expects:
+\itemize{
+\item Each value in \code{needles} matches at most 1 value in \code{haystack}.
+\item Each value in \code{haystack} matches at most 1 value in \code{needles}.
+}
+\item \code{"one-to-many"} expects:
+\itemize{
+\item Each value in \code{needles} matches any number of values in \code{haystack}.
+\item Each value in \code{haystack} matches at most 1 value in \code{needles}.
+}
+\item \code{"many-to-one"} expects:
+\itemize{
+\item Each value in \code{needles} matches at most 1 value in \code{haystack}.
+\item Each value in \code{haystack} matches any number of values in \code{needles}.
+}
+\item \code{"many-to-many"} expects:
+\itemize{
+\item Each value in \code{needles} matches any number of values in \code{haystack}.
+\item Each value in \code{haystack} matches any number of values in \code{needles}.
+}
+
+This performs no checks, and is identical to \code{"none"}, but is provided to
+allow you to be explicit about this relationship if you know it exists.
+\item \code{"warn-many-to-many"} doesn't assume there is any known relationship, but
+will warn if \code{needles} and \code{haystack} have a many-to-many relationship
+(which is typically unexpected), encouraging you to either take a closer
+look at your inputs or make this relationship explicit by specifying
+\code{"many-to-many"}.
+}
+
+\code{relationship} is applied after \code{filter} and \code{multiple} to allow potential
+multiple matches to be filtered out first.
+
+\code{relationship} doesn't handle cases where there are zero matches. For that,
+see \code{no_match} and \code{remaining}.}
 }
 \value{
 A data frame containing two integer columns named \code{needles} and \code{haystack}.

--- a/man/relation-locate.Rd
+++ b/man/relation-locate.Rd
@@ -15,7 +15,8 @@ iv_locate_overlaps(
   missing = "equals",
   no_match = NA_integer_,
   remaining = "drop",
-  multiple = "all"
+  multiple = "all",
+  relationship = "none"
 )
 
 iv_locate_precedes(
@@ -26,7 +27,8 @@ iv_locate_precedes(
   missing = "equals",
   no_match = NA_integer_,
   remaining = "drop",
-  multiple = "all"
+  multiple = "all",
+  relationship = "none"
 )
 
 iv_locate_follows(
@@ -37,7 +39,8 @@ iv_locate_follows(
   missing = "equals",
   no_match = NA_integer_,
   remaining = "drop",
-  multiple = "all"
+  multiple = "all",
+  relationship = "none"
 )
 }
 \arguments{
@@ -115,6 +118,47 @@ which match will be returned. It is often faster than \code{"first"} and
 \item \code{"first"} returns the first match detected in \code{haystack}.
 \item \code{"last"} returns the last match detected in \code{haystack}.
 }}
+
+\item{relationship}{Handling of the expected relationship between
+\code{needles} and \code{haystack}. If the expectations chosen from the list below
+are invalidated, an error is thrown.
+\itemize{
+\item \code{"none"} doesn't perform any relationship checks.
+\item \code{"one-to-one"} expects:
+\itemize{
+\item Each value in \code{needles} matches at most 1 value in \code{haystack}.
+\item Each value in \code{haystack} matches at most 1 value in \code{needles}.
+}
+\item \code{"one-to-many"} expects:
+\itemize{
+\item Each value in \code{needles} matches any number of values in \code{haystack}.
+\item Each value in \code{haystack} matches at most 1 value in \code{needles}.
+}
+\item \code{"many-to-one"} expects:
+\itemize{
+\item Each value in \code{needles} matches at most 1 value in \code{haystack}.
+\item Each value in \code{haystack} matches any number of values in \code{needles}.
+}
+\item \code{"many-to-many"} expects:
+\itemize{
+\item Each value in \code{needles} matches any number of values in \code{haystack}.
+\item Each value in \code{haystack} matches any number of values in \code{needles}.
+}
+
+This performs no checks, and is identical to \code{"none"}, but is provided to
+allow you to be explicit about this relationship if you know it exists.
+\item \code{"warn-many-to-many"} doesn't assume there is any known relationship, but
+will warn if \code{needles} and \code{haystack} have a many-to-many relationship
+(which is typically unexpected), encouraging you to either take a closer
+look at your inputs or make this relationship explicit by specifying
+\code{"many-to-many"}.
+}
+
+\code{relationship} is applied after \code{filter} and \code{multiple} to allow potential
+multiple matches to be filtered out first.
+
+\code{relationship} doesn't handle cases where there are zero matches. For that,
+see \code{no_match} and \code{remaining}.}
 
 \item{closest}{\verb{[TRUE / FALSE]}
 

--- a/man/vector-locate.Rd
+++ b/man/vector-locate.Rd
@@ -13,7 +13,8 @@ iv_locate_between(
   missing = "equals",
   no_match = NA_integer_,
   remaining = "drop",
-  multiple = "all"
+  multiple = "all",
+  relationship = "none"
 )
 
 iv_locate_includes(
@@ -23,7 +24,8 @@ iv_locate_includes(
   missing = "equals",
   no_match = NA_integer_,
   remaining = "drop",
-  multiple = "all"
+  multiple = "all",
+  relationship = "none"
 )
 }
 \arguments{
@@ -85,6 +87,47 @@ which match will be returned. It is often faster than \code{"first"} and
 \item \code{"first"} returns the first match detected in \code{haystack}.
 \item \code{"last"} returns the last match detected in \code{haystack}.
 }}
+
+\item{relationship}{Handling of the expected relationship between
+\code{needles} and \code{haystack}. If the expectations chosen from the list below
+are invalidated, an error is thrown.
+\itemize{
+\item \code{"none"} doesn't perform any relationship checks.
+\item \code{"one-to-one"} expects:
+\itemize{
+\item Each value in \code{needles} matches at most 1 value in \code{haystack}.
+\item Each value in \code{haystack} matches at most 1 value in \code{needles}.
+}
+\item \code{"one-to-many"} expects:
+\itemize{
+\item Each value in \code{needles} matches any number of values in \code{haystack}.
+\item Each value in \code{haystack} matches at most 1 value in \code{needles}.
+}
+\item \code{"many-to-one"} expects:
+\itemize{
+\item Each value in \code{needles} matches at most 1 value in \code{haystack}.
+\item Each value in \code{haystack} matches any number of values in \code{needles}.
+}
+\item \code{"many-to-many"} expects:
+\itemize{
+\item Each value in \code{needles} matches any number of values in \code{haystack}.
+\item Each value in \code{haystack} matches any number of values in \code{needles}.
+}
+
+This performs no checks, and is identical to \code{"none"}, but is provided to
+allow you to be explicit about this relationship if you know it exists.
+\item \code{"warn-many-to-many"} doesn't assume there is any known relationship, but
+will warn if \code{needles} and \code{haystack} have a many-to-many relationship
+(which is typically unexpected), encouraging you to either take a closer
+look at your inputs or make this relationship explicit by specifying
+\code{"many-to-many"}.
+}
+
+\code{relationship} is applied after \code{filter} and \code{multiple} to allow potential
+multiple matches to be filtered out first.
+
+\code{relationship} doesn't handle cases where there are zero matches. For that,
+see \code{no_match} and \code{remaining}.}
 }
 \value{
 A data frame containing two integer columns named \code{needles} and \code{haystack}.

--- a/tests/testthat/_snaps/relation.md
+++ b/tests/testthat/_snaps/relation.md
@@ -17,6 +17,16 @@
       ! `needles` can't contain missing values.
       x Location 1 contains missing values.
 
+# iv_locate_overlaps - can error on invalid relationships
+
+    Code
+      (expect_error(iv_locate_overlaps(x, y, relationship = "many-to-one")))
+    Output
+      <error/vctrs_error_matches_relationship_many_to_one>
+      Error in `iv_locate_overlaps()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
+
 # iv_count_overlaps - can error on missing needles
 
     Code
@@ -63,6 +73,27 @@
       ! `needles` can't contain missing values.
       x Location 1 contains missing values.
 
+# iv_locate_precedes - can error on invalid relationships
+
+    Code
+      (expect_error(iv_locate_precedes(x, y, relationship = "many-to-one")))
+    Output
+      <error/vctrs_error_matches_relationship_many_to_one>
+      Error in `iv_locate_precedes()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
+
+---
+
+    Code
+      (expect_error(iv_locate_precedes(x, y, relationship = "many-to-one", closest = TRUE))
+      )
+    Output
+      <error/vctrs_error_matches_relationship_many_to_one>
+      Error in `iv_locate_precedes()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
+
 # iv_locate_relates - takes common type
 
     Code
@@ -82,6 +113,17 @@
       Error in `iv_locate_relates()`:
       ! `needles` can't contain missing values.
       x Location 1 contains missing values.
+
+# iv_locate_relates - can error on invalid relationships
+
+    Code
+      (expect_error(iv_locate_relates(x, y, type = "overlaps", relationship = "many-to-one"))
+      )
+    Output
+      <error/vctrs_error_matches_relationship_many_to_one>
+      Error in `iv_locate_relates()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
 
 # iv_count_relates - can error on missing needles
 

--- a/tests/testthat/_snaps/vector.md
+++ b/tests/testthat/_snaps/vector.md
@@ -27,6 +27,16 @@
       ! `needles` can't contain missing values.
       x Location 1 contains missing values.
 
+# between can error on invalid relationships
+
+    Code
+      (expect_error(iv_locate_between(x, y, relationship = "many-to-one")))
+    Output
+      <error/vctrs_error_matches_relationship_many_to_one>
+      Error in `iv_locate_between()`:
+      ! Each value of `needles` can match at most 1 value from `haystack`.
+      x Location 1 of `needles` matches multiple values.
+
 # includes takes the common type
 
     Code
@@ -55,6 +65,16 @@
       Error in `iv_count_includes()`:
       ! `needles` can't contain missing values.
       x Location 1 contains missing values.
+
+# includes can error on invalid relationships
+
+    Code
+      (expect_error(iv_locate_includes(x, y, relationship = "one-to-many")))
+    Output
+      <error/vctrs_error_matches_relationship_one_to_many>
+      Error in `iv_locate_includes()`:
+      ! Each value of `haystack` can match at most 1 value from `needles`.
+      x Location 1 of `haystack` matches multiple values.
 
 # between can error on unmatched needles
 

--- a/tests/testthat/test-relation.R
+++ b/tests/testthat/test-relation.R
@@ -30,6 +30,15 @@ test_that("can error on missing needles", {
   )
 })
 
+test_that("iv_locate_overlaps - can error on invalid relationships", {
+  x <- iv(1, 5)
+  y <- iv_pairs(c(1, 3), c(4, 6))
+
+  expect_snapshot({
+    (expect_error(iv_locate_overlaps(x, y, relationship = "many-to-one")))
+  })
+})
+
 # ------------------------------------------------------------------------------
 # iv_count_overlaps()
 
@@ -308,6 +317,27 @@ test_that("iv_locate_precedes - can error on missing needles", {
   )
 })
 
+test_that("iv_locate_precedes - can error on invalid relationships", {
+  x <- iv(1, 5)
+  y <- iv_pairs(c(6, 7), c(7, 8))
+
+  expect_snapshot({
+    (expect_error(iv_locate_precedes(x, y, relationship = "many-to-one")))
+  })
+
+  # But not with `closest`
+  out <- iv_locate_precedes(x, y, relationship = "many-to-one", closest = TRUE)
+  expect_identical(out$needles, 1L)
+  expect_identical(out$haystack, 1L)
+
+  # Unless there are ties
+  y <- iv_pairs(c(6, 7), c(6, 7))
+
+  expect_snapshot({
+    (expect_error(iv_locate_precedes(x, y, relationship = "many-to-one", closest = TRUE)))
+  })
+})
+
 # ------------------------------------------------------------------------------
 # iv_count_precedes()
 
@@ -517,6 +547,15 @@ test_that("iv_locate_relates - can error on missing needles", {
   expect_snapshot(
     (expect_error(iv_locate_relates(iv(NA, NA), iv(1, 2), type = "equals", missing = "error")))
   )
+})
+
+test_that("iv_locate_relates - can error on invalid relationships", {
+  x <- iv(1, 5)
+  y <- iv_pairs(c(3, 7), c(4, 8))
+
+  expect_snapshot({
+    (expect_error(iv_locate_relates(x, y, type = "overlaps", relationship = "many-to-one")))
+  })
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-vector.R
+++ b/tests/testthat/test-vector.R
@@ -51,6 +51,15 @@ test_that("between can error on missing needles", {
   )
 })
 
+test_that("between can error on invalid relationships", {
+  x <- 1
+  y <- iv_pairs(c(1, 3), c(0, 2))
+
+  expect_snapshot({
+    (expect_error(iv_locate_between(x, y, relationship = "many-to-one")))
+  })
+})
+
 # ------------------------------------------------------------------------------
 # iv_locate_includes()
 
@@ -102,6 +111,15 @@ test_that("includes can error on missing needles", {
   expect_snapshot(
     (expect_error(iv_locate_includes(iv(NA, NA), 1, missing = "error")))
   )
+})
+
+test_that("includes can error on invalid relationships", {
+  x <- iv_pairs(c(1, 3), c(0, 2))
+  y <- 1
+
+  expect_snapshot({
+    (expect_error(iv_locate_includes(x, y, relationship = "one-to-many")))
+  })
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/DavisVaughan/ivs/issues/45

Could also be exposed in the "count" and "detect" style functions like `iv_count_overlaps()` and `iv_overlaps()`, but it doesn't seem like it would be super useful there so we won't do it unless requested